### PR TITLE
feat(api-mgmt): Add Grafana dashboards and event correlation

### DIFF
--- a/pkg/apimgmt/events/correlator.go
+++ b/pkg/apimgmt/events/correlator.go
@@ -1,0 +1,190 @@
+package events
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// EventType classifies events for correlation.
+type EventType string
+
+const (
+	EventConfigChange  EventType = "config_change"
+	EventDeploy        EventType = "deploy"
+	EventErrorSpike    EventType = "error_spike"
+	EventLatencySpike  EventType = "latency_spike"
+	EventCertEvent     EventType = "cert_event"
+	EventScaling       EventType = "scaling"
+)
+
+// Event represents a system event.
+type Event struct {
+	ID        string            `json:"id"`
+	Type      EventType         `json:"type"`
+	Source    string            `json:"source"`
+	Message  string            `json:"message"`
+	Severity string            `json:"severity"` // info, warning, critical
+	Timestamp time.Time         `json:"timestamp"`
+	Metadata map[string]string  `json:"metadata,omitempty"`
+}
+
+// CorrelationGroup holds correlated events that likely share a root cause.
+type CorrelationGroup struct {
+	ID        string    `json:"id"`
+	RootCause string    `json:"rootCause,omitempty"`
+	Events    []Event   `json:"events"`
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
+}
+
+// Config holds event correlation configuration.
+type Config struct {
+	RetentionPeriod   time.Duration `json:"retentionPeriod,omitempty"`
+	CorrelationWindow time.Duration `json:"correlationWindow,omitempty"`
+	MaxEvents         int           `json:"maxEvents,omitempty"`
+}
+
+// Correlator aggregates events and groups them by time proximity.
+type Correlator struct {
+	mu       sync.RWMutex
+	events   []Event
+	window   time.Duration
+	maxEvents int
+	retention time.Duration
+}
+
+// New creates a new event correlator.
+func New(config Config) *Correlator {
+	window := config.CorrelationWindow
+	if window <= 0 {
+		window = 5 * time.Minute
+	}
+	retention := config.RetentionPeriod
+	if retention <= 0 {
+		retention = 24 * time.Hour
+	}
+	maxEvents := config.MaxEvents
+	if maxEvents <= 0 {
+		maxEvents = 10000
+	}
+	return &Correlator{
+		events:    make([]Event, 0, 256),
+		window:    window,
+		maxEvents: maxEvents,
+		retention: retention,
+	}
+}
+
+// Record adds an event.
+func (c *Correlator) Record(event Event) {
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.events) >= c.maxEvents {
+		c.events = c.events[1:]
+	}
+	c.events = append(c.events, event)
+}
+
+// Correlate returns groups of events within the correlation window.
+func (c *Correlator) Correlate() []CorrelationGroup {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if len(c.events) == 0 {
+		return nil
+	}
+
+	var groups []CorrelationGroup
+	used := make(map[int]bool)
+
+	for i, ev := range c.events {
+		if used[i] {
+			continue
+		}
+		group := CorrelationGroup{
+			ID:        ev.ID,
+			Events:    []Event{ev},
+			StartTime: ev.Timestamp,
+			EndTime:   ev.Timestamp,
+		}
+		used[i] = true
+
+		for j := i + 1; j < len(c.events); j++ {
+			if used[j] {
+				continue
+			}
+			if c.events[j].Timestamp.Sub(group.StartTime) <= c.window {
+				group.Events = append(group.Events, c.events[j])
+				if c.events[j].Timestamp.After(group.EndTime) {
+					group.EndTime = c.events[j].Timestamp
+				}
+				used[j] = true
+			}
+		}
+
+		if len(group.Events) > 1 {
+			group.RootCause = inferRootCause(group.Events)
+			groups = append(groups, group)
+		}
+	}
+
+	return groups
+}
+
+// Timeline returns events in chronological order within a time range.
+func (c *Correlator) Timeline(from, to time.Time) []Event {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var result []Event
+	for _, ev := range c.events {
+		if (ev.Timestamp.Equal(from) || ev.Timestamp.After(from)) && ev.Timestamp.Before(to) {
+			result = append(result, ev)
+		}
+	}
+	return result
+}
+
+// Cleanup removes events older than retention period.
+func (c *Correlator) Cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cutoff := time.Now().Add(-c.retention)
+	i := 0
+	for i < len(c.events) && c.events[i].Timestamp.Before(cutoff) {
+		i++
+	}
+	c.events = c.events[i:]
+}
+
+// ServeHTTP serves correlated events as JSON.
+func (c *Correlator) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(rw).Encode(c.Correlate())
+}
+
+// inferRootCause attempts to identify the most likely root cause from correlated events.
+func inferRootCause(events []Event) string {
+	// Priority: config_change > deploy > scaling > cert_event > error_spike > latency_spike
+	priority := map[EventType]int{
+		EventConfigChange: 6, EventDeploy: 5, EventScaling: 4,
+		EventCertEvent: 3, EventErrorSpike: 2, EventLatencySpike: 1,
+	}
+	var best Event
+	bestPri := 0
+	for _, ev := range events {
+		if p := priority[ev.Type]; p > bestPri {
+			bestPri = p
+			best = ev
+		}
+	}
+	if bestPri > 0 {
+		return string(best.Type) + ": " + best.Message
+	}
+	return "unknown"
+}

--- a/pkg/apimgmt/grafana/dashboards.go
+++ b/pkg/apimgmt/grafana/dashboards.go
@@ -1,0 +1,119 @@
+package grafana
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Dashboard represents a Grafana dashboard definition.
+type Dashboard struct {
+	Title       string  `json:"title"`
+	UID         string  `json:"uid"`
+	Description string  `json:"description,omitempty"`
+	Panels      []Panel `json:"panels"`
+	Templating  []Var   `json:"templating,omitempty"`
+}
+
+// Panel represents a Grafana panel.
+type Panel struct {
+	Title   string  `json:"title"`
+	Type    string  `json:"type"` // graph, stat, gauge, table, heatmap
+	GridPos GridPos `json:"gridPos"`
+	Targets []Target `json:"targets"`
+}
+
+// GridPos defines panel position.
+type GridPos struct {
+	H int `json:"h"`
+	W int `json:"w"`
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// Target holds a Prometheus query.
+type Target struct {
+	Expr   string `json:"expr"`
+	Legend string `json:"legendFormat,omitempty"`
+}
+
+// Var holds a template variable.
+type Var struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Query string `json:"query,omitempty"`
+}
+
+// BuiltinDashboards returns all pre-built dashboard definitions.
+func BuiltinDashboards() []Dashboard {
+	return []Dashboard{
+		overviewDashboard(),
+		authDashboard(),
+		aiGatewayDashboard(),
+		mcpGatewayDashboard(),
+		securityDashboard(),
+	}
+}
+
+func overviewDashboard() Dashboard {
+	return Dashboard{
+		Title: "Traefik Overview", UID: "traefik-overview",
+		Description: "Request rates, error rates, latency percentiles, active connections",
+		Panels: []Panel{
+			{Title: "Requests/s", Type: "graph", GridPos: GridPos{8, 12, 0, 0}, Targets: []Target{{Expr: `rate(traefik_entrypoint_requests_total[5m])`, Legend: "{{entrypoint}}"}}},
+			{Title: "Error Rate", Type: "graph", GridPos: GridPos{8, 12, 12, 0}, Targets: []Target{{Expr: `rate(traefik_entrypoint_requests_total{code=~"5.."}[5m]) / rate(traefik_entrypoint_requests_total[5m])`, Legend: "{{entrypoint}}"}}},
+			{Title: "Latency p95", Type: "graph", GridPos: GridPos{8, 12, 0, 8}, Targets: []Target{{Expr: `histogram_quantile(0.95, rate(traefik_entrypoint_request_duration_seconds_bucket[5m]))`, Legend: "p95"}}},
+			{Title: "Active Connections", Type: "stat", GridPos: GridPos{4, 6, 12, 8}, Targets: []Target{{Expr: `traefik_entrypoint_open_connections`}}},
+		},
+	}
+}
+
+func authDashboard() Dashboard {
+	return Dashboard{
+		Title: "Authentication", UID: "traefik-auth",
+		Panels: []Panel{
+			{Title: "Auth Success Rate", Type: "gauge", GridPos: GridPos{6, 8, 0, 0}, Targets: []Target{{Expr: `sum(rate(traefik_middleware_requests_total{middleware_type=~"JWTAuth|OIDC|APIKey|LDAP|HMAC",code!~"4.."}[5m])) / sum(rate(traefik_middleware_requests_total{middleware_type=~"JWTAuth|OIDC|APIKey|LDAP|HMAC"}[5m]))`}}},
+			{Title: "Auth Failures by Type", Type: "graph", GridPos: GridPos{8, 16, 8, 0}, Targets: []Target{{Expr: `rate(traefik_middleware_requests_total{middleware_type=~"JWTAuth|OIDC|APIKey|LDAP|HMAC",code=~"4.."}[5m])`, Legend: "{{middleware_type}}"}}},
+		},
+	}
+}
+
+func aiGatewayDashboard() Dashboard {
+	return Dashboard{
+		Title: "AI Gateway", UID: "traefik-ai",
+		Panels: []Panel{
+			{Title: "AI Requests/s", Type: "graph", GridPos: GridPos{8, 12, 0, 0}, Targets: []Target{{Expr: `rate(ai_requests_total[5m])`, Legend: "{{ai_provider}}"}}},
+			{Title: "Token Usage", Type: "graph", GridPos: GridPos{8, 12, 12, 0}, Targets: []Target{{Expr: `rate(ai_tokens_total[5m])`, Legend: "{{ai_model}}"}}},
+			{Title: "Estimated Cost (USD/h)", Type: "stat", GridPos: GridPos{4, 6, 0, 8}, Targets: []Target{{Expr: `rate(ai_cost_total_usd[1h]) * 3600`}}},
+			{Title: "Latency by Provider", Type: "graph", GridPos: GridPos{8, 12, 6, 8}, Targets: []Target{{Expr: `histogram_quantile(0.95, rate(ai_request_duration_seconds_bucket[5m]))`, Legend: "{{ai_provider}} p95"}}},
+			{Title: "Cache Hit Rate", Type: "gauge", GridPos: GridPos{4, 6, 18, 8}, Targets: []Target{{Expr: `sum(rate(ai_cache_hits_total[5m])) / sum(rate(ai_requests_total[5m]))`}}},
+		},
+	}
+}
+
+func mcpGatewayDashboard() Dashboard {
+	return Dashboard{
+		Title: "MCP Gateway", UID: "traefik-mcp",
+		Panels: []Panel{
+			{Title: "Tool Invocations/s", Type: "graph", GridPos: GridPos{8, 12, 0, 0}, Targets: []Target{{Expr: `rate(mcp_tool_invocations_total[5m])`, Legend: "{{tool}}"}}},
+			{Title: "Policy Decisions", Type: "graph", GridPos: GridPos{8, 12, 12, 0}, Targets: []Target{{Expr: `rate(mcp_policy_decisions_total[5m])`, Legend: "{{action}}"}}},
+			{Title: "Active Sessions", Type: "stat", GridPos: GridPos{4, 6, 0, 8}, Targets: []Target{{Expr: `mcp_active_sessions`}}},
+		},
+	}
+}
+
+func securityDashboard() Dashboard {
+	return Dashboard{
+		Title: "Security", UID: "traefik-security",
+		Panels: []Panel{
+			{Title: "WAF Blocks/s", Type: "graph", GridPos: GridPos{8, 8, 0, 0}, Targets: []Target{{Expr: `rate(traefik_middleware_requests_total{middleware_type="WAF",code="403"}[5m])`}}},
+			{Title: "OPA Denials/s", Type: "graph", GridPos: GridPos{8, 8, 8, 0}, Targets: []Target{{Expr: `rate(traefik_middleware_requests_total{middleware_type="OPA",code="403"}[5m])`}}},
+			{Title: "PII Detections", Type: "stat", GridPos: GridPos{4, 8, 16, 0}, Targets: []Target{{Expr: `sum(increase(ai_pii_detections_total[24h]))`}}},
+		},
+	}
+}
+
+// ServeHTTP serves dashboard definitions as JSON.
+func ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(rw).Encode(BuiltinDashboards())
+}


### PR DESCRIPTION
Closes #32, Closes #33

- 5 pre-built Grafana dashboards with Prometheus queries
- Event correlation engine with root cause inference