### PR TITLE
fix(webui): remove residual Hub demo references

### DIFF
--- a/webui/src/layout/Page.tsx
+++ b/webui/src/layout/Page.tsx
@@ -42,24 +42,17 @@ export interface Props {
 }
 
 const Page = ({ children }: Props) => {
-  const { pathname } = useLocation()
   const [isSideBarPanelOpen, setIsSideBarPanelOpen] = useState(false)
   const location = useLocation()
 
-  const isDemoPage = useMemo(() => pathname.includes('hub-dashboard'), [pathname])
-
   const renderedContent = useMemo(() => {
-    if (isDemoPage) {
-      return children
-    }
-
     return (
       <PageContainer data-testid={`${location.pathname} page`} direction="column">
         <TopNav />
         {children}
       </PageContainer>
     )
-  }, [children, isDemoPage, location.pathname])
+  }, [children, location.pathname])
 
   return (
     <ToastProvider>

--- a/webui/src/types/global.d.ts
+++ b/webui/src/types/global.d.ts
@@ -1,10 +1,3 @@
 interface Window {
   APIUrl: string
 }
-
-declare namespace JSX {
-  interface IntrinsicElements {
-    'hub-button-app': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
-    'hub-ui-demo-app': { key: string; path: string; theme: 'dark' | 'light'; baseurl: string; containercss: string }
-  }
-}


### PR DESCRIPTION
Ref #77

- Remove isDemoPage check from Page.tsx (hub-dashboard path)
- Remove hub-button-app and hub-ui-demo-app type declarations from global.d.ts
- Remove unused pathname destructuring from Page component