### PR TITLE
feat(webui): connect dashboard pages to real backend API

### DIFF
--- a/webui/src/pages/ai/AIGateway.tsx
+++ b/webui/src/pages/ai/AIGateway.tsx
@@ -1,18 +1,5 @@
 import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
-import PageTitle from 'layout/PageTitle'
-
-const providers = [
-  { name: 'OpenAI', type: 'openai', status: 'healthy' },
-  { name: 'Anthropic', type: 'anthropic', status: 'healthy' },
-  { name: 'Ollama', type: 'ollama', status: 'unknown' },
-  { name: 'Mistral', type: 'mistral', status: 'unknown' },
-  { name: 'Azure OpenAI', type: 'azure', status: 'unknown' },
-]
-
-const StatusBadge = ({ status }: { status: string }) => {
-  const color = status === 'healthy' ? 'green' : status === 'unhealthy' ? 'red' : 'gray'
-  return <Badge variant={color}>{status}</Badge>
-}
+import useSWR from 'swr'
 
 const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
   <Card css={{ p: '$4' }}>
@@ -24,52 +11,52 @@ const StatCard = ({ title, value, subtitle }: { title: string; value: string; su
   </Card>
 )
 
-export const AIGateway = () => {
-  return (
-    <Flex direction="column" gap={6}>
-      <PageTitle title="AI Gateway" />
+export function AIGateway() {
+  const { data: middlewares } = useSWR('/http/middlewares')
+  const { data: services } = useSWR('/http/services')
 
-      <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))' }}>
-        <StatCard title="Total Requests" value="0" subtitle="Last 24h" />
-        <StatCard title="Tokens Used" value="0" subtitle="Prompt + Completion" />
-        <StatCard title="Cache Hit Rate" value="—" subtitle="Semantic cache" />
-        <StatCard title="Estimated Cost" value="$0.00" subtitle="Last 24h" />
+  const aiMiddlewares = Array.isArray(middlewares)
+    ? middlewares.filter((m: any) => ['aigateway', 'semanticcache', 'piiguard', 'contentguard'].includes(m.type))
+    : []
+  const aiServices = Array.isArray(services)
+    ? services.filter((s: any) => s.name?.includes('ai') || s.name?.includes('llm') || s.name?.includes('openai'))
+    : []
+
+  return (
+    <Flex direction="column" gap={4}>
+      <H2>AI Gateway</H2>
+
+      <Grid columns={{ '@initial': 2, '@md': 4 }} gap={3}>
+        <StatCard title="AI Middlewares" value={String(aiMiddlewares.length)} subtitle="Gateway/Cache/Guard" />
+        <StatCard title="AI Services" value={String(aiServices.length)} subtitle="LLM backends" />
+        <StatCard title="Semantic Cache" value={aiMiddlewares.filter((m: any) => m.type === 'semanticcache').length > 0 ? 'Active' : 'Inactive'} />
+        <StatCard title="PII Guard" value={aiMiddlewares.filter((m: any) => m.type === 'piiguard' || m.type === 'contentguard').length > 0 ? 'Active' : 'Inactive'} />
       </Grid>
 
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Providers</H2>
-        <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))' }}>
-          {providers.map((p) => (
-            <Card key={p.name} css={{ p: '$4' }}>
-              <Flex direction="column" gap={2}>
-                <Flex justify="between" align="center">
-                  <Text css={{ fontWeight: 600 }}>{p.name}</Text>
-                  <StatusBadge status={p.status} />
-                </Flex>
-                <Text css={{ fontSize: '$2', color: '$textSubtle' }}>Type: {p.type}</Text>
-              </Flex>
-            </Card>
-          ))}
-        </Grid>
-      </Flex>
-
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Credentials</H2>
+      {aiMiddlewares.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>No credentials configured. Add AI provider credentials in the static configuration.</Text>
+          <Flex direction="column" gap={2}>
+            <Text css={{ fontWeight: 600 }}>AI Middlewares</Text>
+            {aiMiddlewares.map((m: any) => (
+              <Flex key={m.name} justify="between" align="center">
+                <Text>{m.name}</Text>
+                <Flex gap={1}>
+                  <Badge>{m.type}</Badge>
+                  <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
+                </Flex>
+              </Flex>
+            ))}
+          </Flex>
         </Card>
-      </Flex>
+      )}
 
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Content Guard</H2>
-        <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))' }}>
-          <StatCard title="PII Detections" value="0" subtitle="Last 24h" />
-          <StatCard title="Injection Blocks" value="0" subtitle="Prompt injection" />
-          <StatCard title="Redactions" value="0" subtitle="Auto-redacted" />
-        </Grid>
-      </Flex>
+      {aiMiddlewares.length === 0 && (
+        <Card css={{ p: '$4' }}>
+          <Text css={{ color: '$textSubtle' }}>
+            No AI Gateway middlewares configured. Add aigateway, semanticcache, or piiguard middlewares to your dynamic configuration.
+          </Text>
+        </Card>
+      )}
     </Flex>
   )
 }
-
-export default AIGateway

--- a/webui/src/pages/apimgmt/APIManagement.tsx
+++ b/webui/src/pages/apimgmt/APIManagement.tsx
@@ -1,5 +1,5 @@
 import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
-import PageTitle from 'layout/PageTitle'
+import useSWR from 'swr'
 
 const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
   <Card css={{ p: '$4' }}>
@@ -11,50 +11,49 @@ const StatCard = ({ title, value, subtitle }: { title: string; value: string; su
   </Card>
 )
 
-export const APIManagement = () => {
-  return (
-    <Flex direction="column" gap={6}>
-      <PageTitle title="API Management" />
+export function APIManagement() {
+  const { data: routers } = useSWR('/http/routers')
+  const { data: services } = useSWR('/http/services')
+  const { data: middlewares } = useSWR('/http/middlewares')
 
-      <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))' }}>
-        <StatCard title="APIs" value="0" subtitle="Registered" />
-        <StatCard title="Developers" value="0" subtitle="Portal users" />
-        <StatCard title="API Keys" value="0" subtitle="Active" />
-        <StatCard title="Config Issues" value="0" subtitle="Linter findings" />
+  const totalRouters = Array.isArray(routers) ? routers.length : 0
+  const totalServices = Array.isArray(services) ? services.length : 0
+  const totalMiddlewares = Array.isArray(middlewares) ? middlewares.length : 0
+  const versioningMiddlewares = Array.isArray(middlewares)
+    ? middlewares.filter((m: any) => m.type === 'apiversioning')
+    : []
+
+  const fileRouters = Array.isArray(routers) ? routers.filter((r: any) => r.provider === 'file') : []
+
+  return (
+    <Flex direction="column" gap={4}>
+      <H2>API Management</H2>
+
+      <Grid columns={{ '@initial': 2, '@md': 4 }} gap={3}>
+        <StatCard title="Total Routers" value={String(totalRouters)} subtitle="HTTP routes" />
+        <StatCard title="Total Services" value={String(totalServices)} subtitle="Backend services" />
+        <StatCard title="Total Middlewares" value={String(totalMiddlewares)} subtitle="Active middlewares" />
+        <StatCard title="API Versioning" value={String(versioningMiddlewares.length)} subtitle="Version routers" />
       </Grid>
 
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>API Catalog</H2>
+      {fileRouters.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>No APIs registered. Define APIs with versioning in the configuration.</Text>
-        </Card>
-      </Flex>
-
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Developer Portal</H2>
-        <Card css={{ p: '$4' }}>
-          <Flex justify="between" align="center">
-            <Text>Self-service portal</Text>
-            <Badge variant="gray">Not enabled</Badge>
+          <Flex direction="column" gap={2}>
+            <Text css={{ fontWeight: 600 }}>API Catalog (File Provider)</Text>
+            {fileRouters.map((r: any) => (
+              <Flex key={r.name} justify="between" align="center">
+                <Flex direction="column">
+                  <Text>{r.name}</Text>
+                  <Text css={{ fontSize: '$2', color: '$textSubtle' }}>{r.rule}</Text>
+                </Flex>
+                <Flex gap={1}>
+                  <Badge variant={r.status === 'enabled' ? 'green' : 'red'}>{r.status}</Badge>
+                </Flex>
+              </Flex>
+            ))}
           </Flex>
         </Card>
-      </Flex>
-
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Traffic Debugger</H2>
-        <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>No traces captured. Enable the traffic debugger to inspect requests.</Text>
-        </Card>
-      </Flex>
-
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Event Correlation</H2>
-        <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>No correlated events. Events will appear when configuration changes or incidents occur.</Text>
-        </Card>
-      </Flex>
+      )}
     </Flex>
   )
 }
-
-export default APIManagement

--- a/webui/src/pages/mcp/MCPGateway.tsx
+++ b/webui/src/pages/mcp/MCPGateway.tsx
@@ -1,5 +1,5 @@
 import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
-import PageTitle from 'layout/PageTitle'
+import useSWR from 'swr'
 
 const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
   <Card css={{ p: '$4' }}>
@@ -11,40 +11,52 @@ const StatCard = ({ title, value, subtitle }: { title: string; value: string; su
   </Card>
 )
 
-export const MCPGateway = () => {
-  return (
-    <Flex direction="column" gap={6}>
-      <PageTitle title="MCP Gateway" />
+export function MCPGateway() {
+  const { data: middlewares } = useSWR('/http/middlewares')
+  const { data: services } = useSWR('/http/services')
 
-      <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))' }}>
-        <StatCard title="MCP Servers" value="0" subtitle="Registered" />
-        <StatCard title="Active Sessions" value="0" />
-        <StatCard title="Tool Invocations" value="0" subtitle="Last 24h" />
-        <StatCard title="Policy Denials" value="0" subtitle="Last 24h" />
+  const mcpMiddlewares = Array.isArray(middlewares)
+    ? middlewares.filter((m: any) => ['tbac', 'mcpgovernance', 'mcppolicy', 'mcpaudit'].includes(m.type))
+    : []
+  const mcpServices = Array.isArray(services)
+    ? services.filter((s: any) => s.name?.includes('mcp'))
+    : []
+
+  return (
+    <Flex direction="column" gap={4}>
+      <H2>MCP Gateway</H2>
+
+      <Grid columns={{ '@initial': 2, '@md': 4 }} gap={3}>
+        <StatCard title="MCP Middlewares" value={String(mcpMiddlewares.length)} subtitle="TBAC/Governance/Policy/Audit" />
+        <StatCard title="MCP Services" value={String(mcpServices.length)} subtitle="MCP server backends" />
+        <StatCard title="TBAC Engine" value={mcpMiddlewares.filter((m: any) => m.type === 'tbac').length > 0 ? 'Active' : 'Inactive'} />
+        <StatCard title="Audit Logger" value={mcpMiddlewares.filter((m: any) => m.type === 'mcpaudit').length > 0 ? 'Active' : 'Inactive'} />
       </Grid>
 
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Server Registry</H2>
+      {mcpMiddlewares.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>No MCP servers registered. Configure servers in the MCP gateway settings.</Text>
+          <Flex direction="column" gap={2}>
+            <Text css={{ fontWeight: 600 }}>MCP Middlewares</Text>
+            {mcpMiddlewares.map((m: any) => (
+              <Flex key={m.name} justify="between" align="center">
+                <Text>{m.name}</Text>
+                <Flex gap={1}>
+                  <Badge>{m.type}</Badge>
+                  <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
+                </Flex>
+              </Flex>
+            ))}
+          </Flex>
         </Card>
-      </Flex>
+      )}
 
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>TBAC Policies</H2>
+      {mcpMiddlewares.length === 0 && (
         <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>No task-based access control policies configured.</Text>
+          <Text css={{ color: '$textSubtle' }}>
+            No MCP Gateway middlewares configured. Add tbac, mcpgovernance, mcppolicy, or mcpaudit middlewares to your dynamic configuration.
+          </Text>
         </Card>
-      </Flex>
-
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Audit Log</H2>
-        <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>No audit events recorded.</Text>
-        </Card>
-      </Flex>
+      )}
     </Flex>
   )
 }
-
-export default MCPGateway

--- a/webui/src/pages/security/Security.tsx
+++ b/webui/src/pages/security/Security.tsx
@@ -1,5 +1,5 @@
 import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
-import PageTitle from 'layout/PageTitle'
+import useSWR from 'swr'
 
 const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
   <Card css={{ p: '$4' }}>
@@ -11,55 +11,71 @@ const StatCard = ({ title, value, subtitle }: { title: string; value: string; su
   </Card>
 )
 
-export const Security = () => {
+export function Security() {
+  const { data: middlewares } = useSWR('/http/middlewares')
+
+  const wafMiddlewares = Array.isArray(middlewares) ? middlewares.filter((m: any) => m.type === 'waf') : []
+  const apiKeyMiddlewares = Array.isArray(middlewares) ? middlewares.filter((m: any) => m.type === 'apikey') : []
+  const authMiddlewares = Array.isArray(middlewares)
+    ? middlewares.filter((m: any) => ['basicauth', 'digestauth', 'forwardauth', 'jwt', 'oidc', 'oauth2introspection', 'hmac', 'ldap'].includes(m.type))
+    : []
+  const opaMiddlewares = Array.isArray(middlewares) ? middlewares.filter((m: any) => m.type === 'opa') : []
+
   return (
-    <Flex direction="column" gap={6}>
-      <PageTitle title="Security" />
+    <Flex direction="column" gap={4}>
+      <H2>Security</H2>
 
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>WAF (Coraza)</H2>
-        <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))' }}>
-          <StatCard title="Requests Inspected" value="0" subtitle="Last 24h" />
-          <StatCard title="Blocked" value="0" subtitle="403 responses" />
-          <StatCard title="SQL Injection" value="0" subtitle="Detected" />
-          <StatCard title="XSS" value="0" subtitle="Detected" />
-        </Grid>
-      </Flex>
+      <Grid columns={{ '@initial': 2, '@md': 4 }} gap={3}>
+        <StatCard title="WAF Rules" value={String(wafMiddlewares.length)} subtitle="Active WAF middlewares" />
+        <StatCard title="API Key Auth" value={String(apiKeyMiddlewares.length)} subtitle="API key middlewares" />
+        <StatCard title="Auth Methods" value={String(authMiddlewares.length)} subtitle="JWT/OIDC/LDAP/OAuth/HMAC" />
+        <StatCard title="OPA Policies" value={String(opaMiddlewares.length)} subtitle="Policy decision points" />
+      </Grid>
 
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>OPA Authorization</H2>
-        <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))' }}>
-          <StatCard title="Evaluations" value="0" />
-          <StatCard title="Allowed" value="0" />
-          <StatCard title="Denied" value="0" />
-        </Grid>
-      </Flex>
-
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Authentication</H2>
-        <Grid gap={4} css={{ gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))' }}>
-          {['JWT', 'OIDC', 'API Key', 'HMAC', 'LDAP', 'OAuth'].map((method) => (
-            <Card key={method} css={{ p: '$4' }}>
-              <Flex justify="between" align="center">
-                <Text css={{ fontWeight: 600 }}>{method}</Text>
-                <Badge variant="gray">No data</Badge>
-              </Flex>
-            </Card>
-          ))}
-        </Grid>
-      </Flex>
-
-      <Flex direction="column" gap={4}>
-        <H2 css={{ fontSize: '$8' }}>Vault</H2>
+      {wafMiddlewares.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Flex justify="between" align="center">
-            <Text>HashiCorp Vault</Text>
-            <Badge variant="gray">Not configured</Badge>
+          <Flex direction="column" gap={2}>
+            <Text css={{ fontWeight: 600 }}>WAF Middlewares</Text>
+            {wafMiddlewares.map((m: any) => (
+              <Flex key={m.name} justify="between" align="center">
+                <Text>{m.name}</Text>
+                <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
+              </Flex>
+            ))}
           </Flex>
         </Card>
-      </Flex>
+      )}
+
+      {apiKeyMiddlewares.length > 0 && (
+        <Card css={{ p: '$4' }}>
+          <Flex direction="column" gap={2}>
+            <Text css={{ fontWeight: 600 }}>API Key Middlewares</Text>
+            {apiKeyMiddlewares.map((m: any) => (
+              <Flex key={m.name} justify="between" align="center">
+                <Text>{m.name}</Text>
+                <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
+              </Flex>
+            ))}
+          </Flex>
+        </Card>
+      )}
+
+      {authMiddlewares.length > 0 && (
+        <Card css={{ p: '$4' }}>
+          <Flex direction="column" gap={2}>
+            <Text css={{ fontWeight: 600 }}>Authentication Middlewares</Text>
+            {authMiddlewares.map((m: any) => (
+              <Flex key={m.name} justify="between" align="center">
+                <Text>{m.name}</Text>
+                <Flex gap={1}>
+                  <Badge>{m.type}</Badge>
+                  <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
+                </Flex>
+              </Flex>
+            ))}
+          </Flex>
+        </Card>
+      )}
     </Flex>
   )
 }
-
-export default Security


### PR DESCRIPTION
Closes #78

- Security page: fetches /http/middlewares, filters by waf/apikey/auth types
- AI Gateway page: fetches middlewares/services, filters AI-related
- MCP Gateway page: fetches middlewares/services, filters MCP-related
- API Management page: shows routers/services/middlewares from real API

All pages now use useSWR with the existing fetch pattern instead of static placeholder data.