### PR TITLE
feat(webui): add configuration forms for AI Gateway, MCP, Security, API Management

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -147,6 +147,15 @@ func (h *Handler) createRouter() *mux.Router {
 		dcm.RegisterCRUDRoutes(apiRouter)
 	}
 
+	// Static configuration management (for AI/MCP/APIMgmt settings).
+	staticPath := findStaticConfigPath()
+	if staticPath != "" {
+		scm := newStaticConfigManager(staticPath)
+		apiRouter.Methods(http.MethodGet).Path("/api/config/static").HandlerFunc(scm.getStaticSection)
+		apiRouter.Methods(http.MethodPut).Path("/api/config/static").HandlerFunc(scm.putStaticSection)
+		apiRouter.Methods(http.MethodDelete).Path("/api/config/static").HandlerFunc(scm.deleteStaticSection)
+	}
+
 	version.Handler{}.Append(apiRouter)
 
 	return router

--- a/pkg/api/handler_static_config.go
+++ b/pkg/api/handler_static_config.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// StaticConfigManager handles read/write of static configuration sections.
+type StaticConfigManager struct {
+	mu       sync.Mutex
+	filePath string
+}
+
+func newStaticConfigManager(filePath string) *StaticConfigManager {
+	return &StaticConfigManager{filePath: filePath}
+}
+
+func (m *StaticConfigManager) load() (map[string]interface{}, error) {
+	data, err := os.ReadFile(m.filePath)
+	if err != nil {
+		return make(map[string]interface{}), nil
+	}
+	var cfg map[string]interface{}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		cfg = make(map[string]interface{})
+	}
+	return cfg, nil
+}
+
+func (m *StaticConfigManager) save(cfg map[string]interface{}) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(m.filePath, data, 0644)
+}
+
+// getStaticSection returns a section of the static config.
+func (m *StaticConfigManager) getStaticSection(rw http.ResponseWriter, req *http.Request) {
+	section := req.URL.Query().Get("section")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cfg, err := m.load()
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if section == "" {
+		rw.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(rw).Encode(cfg)
+		return
+	}
+
+	val, ok := cfg[section]
+	if !ok {
+		rw.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(rw).Encode(nil)
+		return
+	}
+	rw.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(rw).Encode(val)
+}
+
+// putStaticSection updates a section of the static config.
+func (m *StaticConfigManager) putStaticSection(rw http.ResponseWriter, req *http.Request) {
+	section := req.URL.Query().Get("section")
+	if section == "" {
+		http.Error(rw, "section query param required", http.StatusBadRequest)
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cfg, err := m.load()
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	body, _ := io.ReadAll(req.Body)
+	var value interface{}
+	if err := json.Unmarshal(body, &value); err != nil {
+		http.Error(rw, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	cfg[section] = value
+	if err := m.save(cfg); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(rw).Encode(map[string]string{"status": "saved", "section": section, "note": "restart required for static config changes"})
+}
+
+// deleteStaticSection removes a section from the static config.
+func (m *StaticConfigManager) deleteStaticSection(rw http.ResponseWriter, req *http.Request) {
+	section := req.URL.Query().Get("section")
+	if section == "" {
+		http.Error(rw, "section query param required", http.StatusBadRequest)
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cfg, err := m.load()
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	delete(cfg, section)
+	if err := m.save(cfg); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(rw).Encode(map[string]string{"status": "deleted", "section": section})
+}
+
+func findStaticConfigPath() string {
+	paths := []string{
+		os.Getenv("TRAEFIK_CONFIG_FILE"),
+		"/etc/traefik/traefik.yml",
+		"/etc/traefik/traefik.yaml",
+		"/etc/traefik/traefik.toml",
+		"./traefik.yml",
+	}
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}

--- a/webui/src/pages/ai/AIGateway.tsx
+++ b/webui/src/pages/ai/AIGateway.tsx
@@ -1,60 +1,117 @@
-import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
-import useSWR from 'swr'
+import { Badge, Box, Button, Card, Flex, H2, Text, TextField } from '@traefik-labs/faency'
+import { useState } from 'react'
+import { FiPlus, FiSave, FiTrash2 } from 'react-icons/fi'
+import useSWR, { mutate } from 'swr'
 
-const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
-  <Card css={{ p: '$4' }}>
-    <Flex direction="column" gap={1}>
-      <Text css={{ fontSize: '$3', color: '$textSubtle' }}>{title}</Text>
-      <Text css={{ fontSize: '$9', fontWeight: 700 }}>{value}</Text>
-      {subtitle && <Text css={{ fontSize: '$2', color: '$textSubtle' }}>{subtitle}</Text>}
-    </Flex>
-  </Card>
-)
+const API_BASE = (window as any).APIUrl || '/api'
+
+async function fetchSection(section: string) {
+  const res = await fetch(`${API_BASE}/config/static?section=${section}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+async function saveSection(section: string, data: any) {
+  await fetch(`${API_BASE}/config/static?section=${section}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+function ProviderForm({ provider, onSave, onRemove }: { provider?: any; onSave: (p: any) => void; onRemove?: () => void }) {
+  const [name, setName] = useState(provider?.name || '')
+  const [type, setType] = useState(provider?.type || 'openai')
+  const [endpoint, setEndpoint] = useState(provider?.endpoint || '')
+  const [models, setModels] = useState(provider?.models?.join(', ') || '')
+
+  return (
+    <Card css={{ p: '$3', mb: '$2' }}>
+      <Flex direction="column" gap={2}>
+        <Flex gap={2}>
+          <TextField label="Name" value={name} onChange={(e: any) => setName(e.target.value)} css={{ flex: 1 }} />
+          <TextField label="Type" value={type} onChange={(e: any) => setType(e.target.value)} css={{ flex: 1 }} />
+        </Flex>
+        <TextField label="Endpoint" value={endpoint} onChange={(e: any) => setEndpoint(e.target.value)} />
+        <TextField label="Models (comma-separated)" value={models} onChange={(e: any) => setModels(e.target.value)} />
+        <Flex gap={2} justify="end">
+          {onRemove && <Button size="small" variant="red" onClick={onRemove}><FiTrash2 size={12} /> Remove</Button>}
+          <Button size="small" onClick={() => onSave({ name, type, endpoint, models: models.split(',').map((m: string) => m.trim()).filter(Boolean) })}>
+            <FiSave size={12} /> Save
+          </Button>
+        </Flex>
+      </Flex>
+    </Card>
+  )
+}
 
 export function AIGateway() {
+  const { data: aiConfig, mutate: mutateAI } = useSWR('ai-config', () => fetchSection('ai'))
   const { data: middlewares } = useSWR('/http/middlewares')
-  const { data: services } = useSWR('/http/services')
+
+  const [showAdd, setShowAdd] = useState(false)
+
+  const providers = aiConfig?.providers || []
 
   const aiMiddlewares = Array.isArray(middlewares)
     ? middlewares.filter((m: any) => ['aigateway', 'semanticcache', 'piiguard', 'contentguard'].includes(m.type))
     : []
-  const aiServices = Array.isArray(services)
-    ? services.filter((s: any) => s.name?.includes('ai') || s.name?.includes('llm') || s.name?.includes('openai'))
-    : []
+
+  const handleSaveProvider = async (index: number, provider: any) => {
+    const updated = [...providers]
+    updated[index] = provider
+    await saveSection('ai', { ...aiConfig, providers: updated })
+    mutateAI()
+  }
+
+  const handleAddProvider = async (provider: any) => {
+    const updated = [...providers, provider]
+    await saveSection('ai', { ...aiConfig, providers: updated })
+    mutateAI()
+    setShowAdd(false)
+  }
+
+  const handleRemoveProvider = async (index: number) => {
+    const updated = providers.filter((_: any, i: number) => i !== index)
+    await saveSection('ai', { ...aiConfig, providers: updated })
+    mutateAI()
+  }
 
   return (
     <Flex direction="column" gap={4}>
       <H2>AI Gateway</H2>
 
-      <Grid columns={{ '@initial': 2, '@md': 4 }} gap={3}>
-        <StatCard title="AI Middlewares" value={String(aiMiddlewares.length)} subtitle="Gateway/Cache/Guard" />
-        <StatCard title="AI Services" value={String(aiServices.length)} subtitle="LLM backends" />
-        <StatCard title="Semantic Cache" value={aiMiddlewares.filter((m: any) => m.type === 'semanticcache').length > 0 ? 'Active' : 'Inactive'} />
-        <StatCard title="PII Guard" value={aiMiddlewares.filter((m: any) => m.type === 'piiguard' || m.type === 'contentguard').length > 0 ? 'Active' : 'Inactive'} />
-      </Grid>
+      <Card css={{ p: '$4' }}>
+        <Flex justify="between" align="center" css={{ mb: '$3' }}>
+          <Text css={{ fontWeight: 600 }}>LLM Providers</Text>
+          <Button size="small" onClick={() => setShowAdd(true)}><FiPlus size={14} /> Add Provider</Button>
+        </Flex>
+
+        {providers.map((p: any, i: number) => (
+          <ProviderForm
+            key={i}
+            provider={p}
+            onSave={(updated) => handleSaveProvider(i, updated)}
+            onRemove={() => handleRemoveProvider(i)}
+          />
+        ))}
+
+        {providers.length === 0 && !showAdd && (
+          <Text css={{ color: '$textSubtle' }}>No AI providers configured. Click "Add Provider" to get started.</Text>
+        )}
+
+        {showAdd && <ProviderForm onSave={handleAddProvider} />}
+      </Card>
 
       {aiMiddlewares.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Flex direction="column" gap={2}>
-            <Text css={{ fontWeight: 600 }}>AI Middlewares</Text>
-            {aiMiddlewares.map((m: any) => (
-              <Flex key={m.name} justify="between" align="center">
-                <Text>{m.name}</Text>
-                <Flex gap={1}>
-                  <Badge>{m.type}</Badge>
-                  <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
-                </Flex>
-              </Flex>
-            ))}
-          </Flex>
-        </Card>
-      )}
-
-      {aiMiddlewares.length === 0 && (
-        <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>
-            No AI Gateway middlewares configured. Add aigateway, semanticcache, or piiguard middlewares to your dynamic configuration.
-          </Text>
+          <Text css={{ fontWeight: 600, mb: '$2' }}>Active AI Middlewares</Text>
+          {aiMiddlewares.map((m: any) => (
+            <Flex key={m.name} justify="between" align="center" css={{ py: '$1' }}>
+              <Text>{m.name}</Text>
+              <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.type}</Badge>
+            </Flex>
+          ))}
         </Card>
       )}
     </Flex>

--- a/webui/src/pages/apimgmt/APIManagement.tsx
+++ b/webui/src/pages/apimgmt/APIManagement.tsx
@@ -1,5 +1,23 @@
-import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
+import { Badge, Button, Card, Flex, Grid, H2, Text, TextField } from '@traefik-labs/faency'
+import { useState } from 'react'
+import { FiSave } from 'react-icons/fi'
 import useSWR from 'swr'
+
+const API_BASE = (window as any).APIUrl || '/api'
+
+async function fetchSection(section: string) {
+  const res = await fetch(`${API_BASE}/config/static?section=${section}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+async function saveSection(section: string, data: any) {
+  await fetch(`${API_BASE}/config/static?section=${section}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
 
 const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
   <Card css={{ p: '$4' }}>
@@ -15,15 +33,32 @@ export function APIManagement() {
   const { data: routers } = useSWR('/http/routers')
   const { data: services } = useSWR('/http/services')
   const { data: middlewares } = useSWR('/http/middlewares')
+  const { data: apimgmtConfig, mutate: mutateConfig } = useSWR('apimgmt-config', () => fetchSection('apiMgmt'))
+
+  const [portalTitle, setPortalTitle] = useState('')
+  const [portalPath, setPortalPath] = useState('')
+  const [saved, setSaved] = useState(false)
+
+  // Initialize form from config
+  if (apimgmtConfig?.portal && !portalTitle && !saved) {
+    setPortalTitle(apimgmtConfig.portal.title || '')
+    setPortalPath(apimgmtConfig.portal.basePath || '/portal')
+  }
 
   const totalRouters = Array.isArray(routers) ? routers.length : 0
   const totalServices = Array.isArray(services) ? services.length : 0
   const totalMiddlewares = Array.isArray(middlewares) ? middlewares.length : 0
-  const versioningMiddlewares = Array.isArray(middlewares)
-    ? middlewares.filter((m: any) => m.type === 'apiversioning')
-    : []
-
   const fileRouters = Array.isArray(routers) ? routers.filter((r: any) => r.provider === 'file') : []
+
+  const handleSavePortal = async () => {
+    await saveSection('apiMgmt', {
+      ...apimgmtConfig,
+      portal: { enabled: true, title: portalTitle, basePath: portalPath },
+    })
+    mutateConfig()
+    setSaved(true)
+    setTimeout(() => setSaved(false), 2000)
+  }
 
   return (
     <Flex direction="column" gap={4}>
@@ -33,25 +68,33 @@ export function APIManagement() {
         <StatCard title="Total Routers" value={String(totalRouters)} subtitle="HTTP routes" />
         <StatCard title="Total Services" value={String(totalServices)} subtitle="Backend services" />
         <StatCard title="Total Middlewares" value={String(totalMiddlewares)} subtitle="Active middlewares" />
-        <StatCard title="API Versioning" value={String(versioningMiddlewares.length)} subtitle="Version routers" />
+        <StatCard title="APIs (File)" value={String(fileRouters.length)} subtitle="Managed APIs" />
       </Grid>
+
+      <Card css={{ p: '$4' }}>
+        <Text css={{ fontWeight: 600, mb: '$3' }}>Developer Portal Settings</Text>
+        <Flex direction="column" gap={2}>
+          <TextField label="Portal Title" value={portalTitle} onChange={(e: any) => setPortalTitle(e.target.value)} placeholder="My API Portal" />
+          <TextField label="Base Path" value={portalPath} onChange={(e: any) => setPortalPath(e.target.value)} placeholder="/portal" />
+          <Flex justify="end" gap={2}>
+            {saved && <Text css={{ color: '$green9', fontSize: '$2' }}>Saved! Restart required.</Text>}
+            <Button size="small" onClick={handleSavePortal}><FiSave size={14} /> Save Portal Config</Button>
+          </Flex>
+        </Flex>
+      </Card>
 
       {fileRouters.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Flex direction="column" gap={2}>
-            <Text css={{ fontWeight: 600 }}>API Catalog (File Provider)</Text>
-            {fileRouters.map((r: any) => (
-              <Flex key={r.name} justify="between" align="center">
-                <Flex direction="column">
-                  <Text>{r.name}</Text>
-                  <Text css={{ fontSize: '$2', color: '$textSubtle' }}>{r.rule}</Text>
-                </Flex>
-                <Flex gap={1}>
-                  <Badge variant={r.status === 'enabled' ? 'green' : 'red'}>{r.status}</Badge>
-                </Flex>
+          <Text css={{ fontWeight: 600, mb: '$2' }}>API Catalog (File Provider)</Text>
+          {fileRouters.map((r: any) => (
+            <Flex key={r.name} justify="between" align="center" css={{ py: '$1' }}>
+              <Flex direction="column">
+                <Text>{r.name}</Text>
+                <Text css={{ fontSize: '$2', color: '$textSubtle' }}>{r.rule}</Text>
               </Flex>
-            ))}
-          </Flex>
+              <Badge variant={r.status === 'enabled' ? 'green' : 'red'}>{r.status}</Badge>
+            </Flex>
+          ))}
         </Card>
       )}
     </Flex>

--- a/webui/src/pages/mcp/MCPGateway.tsx
+++ b/webui/src/pages/mcp/MCPGateway.tsx
@@ -1,60 +1,138 @@
-import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
+import { Badge, Button, Card, Flex, H2, Text, TextField } from '@traefik-labs/faency'
+import { useState } from 'react'
+import { FiPlus, FiSave, FiTrash2 } from 'react-icons/fi'
 import useSWR from 'swr'
 
-const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
-  <Card css={{ p: '$4' }}>
-    <Flex direction="column" gap={1}>
-      <Text css={{ fontSize: '$3', color: '$textSubtle' }}>{title}</Text>
-      <Text css={{ fontSize: '$9', fontWeight: 700 }}>{value}</Text>
-      {subtitle && <Text css={{ fontSize: '$2', color: '$textSubtle' }}>{subtitle}</Text>}
-    </Flex>
-  </Card>
-)
+const API_BASE = (window as any).APIUrl || '/api'
+
+async function fetchSection(section: string) {
+  const res = await fetch(`${API_BASE}/config/static?section=${section}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+async function saveSection(section: string, data: any) {
+  await fetch(`${API_BASE}/config/static?section=${section}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+function ServerForm({ server, onSave, onRemove }: { server?: any; onSave: (s: any) => void; onRemove?: () => void }) {
+  const [name, setName] = useState(server?.name || '')
+  const [endpoint, setEndpoint] = useState(server?.endpoint || '')
+  const [protocol, setProtocol] = useState(server?.protocol || 'stdio')
+
+  return (
+    <Card css={{ p: '$3', mb: '$2' }}>
+      <Flex direction="column" gap={2}>
+        <Flex gap={2}>
+          <TextField label="Name" value={name} onChange={(e: any) => setName(e.target.value)} css={{ flex: 1 }} />
+          <TextField label="Protocol" value={protocol} onChange={(e: any) => setProtocol(e.target.value)} css={{ flex: 1 }} />
+        </Flex>
+        <TextField label="Endpoint" value={endpoint} onChange={(e: any) => setEndpoint(e.target.value)} />
+        <Flex gap={2} justify="end">
+          {onRemove && <Button size="small" variant="red" onClick={onRemove}><FiTrash2 size={12} /> Remove</Button>}
+          <Button size="small" onClick={() => onSave({ name, endpoint, protocol })}><FiSave size={12} /> Save</Button>
+        </Flex>
+      </Flex>
+    </Card>
+  )
+}
+
+function PolicyForm({ policy, onSave, onRemove }: { policy?: any; onSave: (p: any) => void; onRemove?: () => void }) {
+  const [name, setName] = useState(policy?.name || '')
+  const [action, setAction] = useState(policy?.action || 'allow')
+  const [priority, setPriority] = useState(String(policy?.priority || 0))
+
+  return (
+    <Card css={{ p: '$3', mb: '$2' }}>
+      <Flex gap={2}>
+        <TextField label="Name" value={name} onChange={(e: any) => setName(e.target.value)} css={{ flex: 2 }} />
+        <TextField label="Action" value={action} onChange={(e: any) => setAction(e.target.value)} css={{ flex: 1 }} />
+        <TextField label="Priority" value={priority} onChange={(e: any) => setPriority(e.target.value)} css={{ flex: 1 }} />
+      </Flex>
+      <Flex gap={2} justify="end" css={{ mt: '$2' }}>
+        {onRemove && <Button size="small" variant="red" onClick={onRemove}><FiTrash2 size={12} /></Button>}
+        <Button size="small" onClick={() => onSave({ name, action, priority: parseInt(priority) || 0 })}><FiSave size={12} /></Button>
+      </Flex>
+    </Card>
+  )
+}
 
 export function MCPGateway() {
+  const { data: mcpConfig, mutate: mutateMCP } = useSWR('mcp-config', () => fetchSection('mcp'))
   const { data: middlewares } = useSWR('/http/middlewares')
-  const { data: services } = useSWR('/http/services')
+
+  const [showAddServer, setShowAddServer] = useState(false)
+  const [showAddPolicy, setShowAddPolicy] = useState(false)
+
+  const servers = mcpConfig?.servers || []
+  const policies = mcpConfig?.policies || []
 
   const mcpMiddlewares = Array.isArray(middlewares)
     ? middlewares.filter((m: any) => ['tbac', 'mcpgovernance', 'mcppolicy', 'mcpaudit'].includes(m.type))
     : []
-  const mcpServices = Array.isArray(services)
-    ? services.filter((s: any) => s.name?.includes('mcp'))
-    : []
+
+  const handleSaveServer = async (index: number, server: any) => {
+    const updated = [...servers]; updated[index] = server
+    await saveSection('mcp', { ...mcpConfig, servers: updated }); mutateMCP()
+  }
+  const handleAddServer = async (server: any) => {
+    await saveSection('mcp', { ...mcpConfig, servers: [...servers, server] }); mutateMCP(); setShowAddServer(false)
+  }
+  const handleRemoveServer = async (index: number) => {
+    await saveSection('mcp', { ...mcpConfig, servers: servers.filter((_: any, i: number) => i !== index) }); mutateMCP()
+  }
+  const handleSavePolicy = async (index: number, policy: any) => {
+    const updated = [...policies]; updated[index] = policy
+    await saveSection('mcp', { ...mcpConfig, policies: updated }); mutateMCP()
+  }
+  const handleAddPolicy = async (policy: any) => {
+    await saveSection('mcp', { ...mcpConfig, policies: [...policies, policy] }); mutateMCP(); setShowAddPolicy(false)
+  }
+  const handleRemovePolicy = async (index: number) => {
+    await saveSection('mcp', { ...mcpConfig, policies: policies.filter((_: any, i: number) => i !== index) }); mutateMCP()
+  }
 
   return (
     <Flex direction="column" gap={4}>
       <H2>MCP Gateway</H2>
 
-      <Grid columns={{ '@initial': 2, '@md': 4 }} gap={3}>
-        <StatCard title="MCP Middlewares" value={String(mcpMiddlewares.length)} subtitle="TBAC/Governance/Policy/Audit" />
-        <StatCard title="MCP Services" value={String(mcpServices.length)} subtitle="MCP server backends" />
-        <StatCard title="TBAC Engine" value={mcpMiddlewares.filter((m: any) => m.type === 'tbac').length > 0 ? 'Active' : 'Inactive'} />
-        <StatCard title="Audit Logger" value={mcpMiddlewares.filter((m: any) => m.type === 'mcpaudit').length > 0 ? 'Active' : 'Inactive'} />
-      </Grid>
+      <Card css={{ p: '$4' }}>
+        <Flex justify="between" align="center" css={{ mb: '$3' }}>
+          <Text css={{ fontWeight: 600 }}>MCP Servers</Text>
+          <Button size="small" onClick={() => setShowAddServer(true)}><FiPlus size={14} /> Add Server</Button>
+        </Flex>
+        {servers.map((s: any, i: number) => (
+          <ServerForm key={i} server={s} onSave={(u) => handleSaveServer(i, u)} onRemove={() => handleRemoveServer(i)} />
+        ))}
+        {servers.length === 0 && !showAddServer && <Text css={{ color: '$textSubtle' }}>No MCP servers configured.</Text>}
+        {showAddServer && <ServerForm onSave={handleAddServer} />}
+      </Card>
+
+      <Card css={{ p: '$4' }}>
+        <Flex justify="between" align="center" css={{ mb: '$3' }}>
+          <Text css={{ fontWeight: 600 }}>Policies</Text>
+          <Button size="small" onClick={() => setShowAddPolicy(true)}><FiPlus size={14} /> Add Policy</Button>
+        </Flex>
+        {policies.map((p: any, i: number) => (
+          <PolicyForm key={i} policy={p} onSave={(u) => handleSavePolicy(i, u)} onRemove={() => handleRemovePolicy(i)} />
+        ))}
+        {policies.length === 0 && !showAddPolicy && <Text css={{ color: '$textSubtle' }}>No policies configured.</Text>}
+        {showAddPolicy && <PolicyForm onSave={handleAddPolicy} />}
+      </Card>
 
       {mcpMiddlewares.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Flex direction="column" gap={2}>
-            <Text css={{ fontWeight: 600 }}>MCP Middlewares</Text>
-            {mcpMiddlewares.map((m: any) => (
-              <Flex key={m.name} justify="between" align="center">
-                <Text>{m.name}</Text>
-                <Flex gap={1}>
-                  <Badge>{m.type}</Badge>
-                  <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
-                </Flex>
-              </Flex>
-            ))}
-          </Flex>
-        </Card>
-      )}
-
-      {mcpMiddlewares.length === 0 && (
-        <Card css={{ p: '$4' }}>
-          <Text css={{ color: '$textSubtle' }}>
-            No MCP Gateway middlewares configured. Add tbac, mcpgovernance, mcppolicy, or mcpaudit middlewares to your dynamic configuration.
-          </Text>
+          <Text css={{ fontWeight: 600, mb: '$2' }}>Active MCP Middlewares</Text>
+          {mcpMiddlewares.map((m: any) => (
+            <Flex key={m.name} justify="between" align="center" css={{ py: '$1' }}>
+              <Text>{m.name}</Text>
+              <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.type}</Badge>
+            </Flex>
+          ))}
         </Card>
       )}
     </Flex>

--- a/webui/src/pages/security/Security.tsx
+++ b/webui/src/pages/security/Security.tsx
@@ -1,5 +1,18 @@
-import { Card, Flex, Grid, H2, Text, Badge } from '@traefik-labs/faency'
-import useSWR from 'swr'
+import { Badge, Button, Card, Flex, Grid, H2, Text } from '@traefik-labs/faency'
+import { useState } from 'react'
+import { FiPlus, FiTrash2 } from 'react-icons/fi'
+import useSWR, { mutate } from 'swr'
+
+const API_BASE = (window as any).APIUrl || '/api'
+
+async function apiCall(method: string, path: string, body?: any) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  return res.json()
+}
 
 const StatCard = ({ title, value, subtitle }: { title: string; value: string; subtitle?: string }) => (
   <Card css={{ p: '$4' }}>
@@ -21,6 +34,30 @@ export function Security() {
     : []
   const opaMiddlewares = Array.isArray(middlewares) ? middlewares.filter((m: any) => m.type === 'opa') : []
 
+  const handleAddWaf = async () => {
+    const name = prompt('WAF middleware name:')
+    if (!name) return
+    const rules = prompt('SecRules (inline):', 'SecRuleEngine On')
+    await apiCall('PUT', `/config/http/middlewares/${name}`, { waf: { inlineRules: rules } })
+    mutate('/http/middlewares')
+  }
+
+  const handleAddApiKey = async () => {
+    const name = prompt('API Key middleware name:')
+    if (!name) return
+    const key = prompt('API Key value:')
+    const header = prompt('Header name:', 'X-API-Key')
+    await apiCall('PUT', `/config/http/middlewares/${name}`, { apiKey: { headerName: header, keys: [{ value: key, metadata: 'user' }] } })
+    mutate('/http/middlewares')
+  }
+
+  const handleDelete = async (mwName: string) => {
+    if (!confirm(`Delete middleware "${mwName}"?`)) return
+    const cleanName = mwName.replace(/@.*/, '')
+    await apiCall('DELETE', `/config/http/middlewares/${cleanName}`)
+    mutate('/http/middlewares')
+  }
+
   return (
     <Flex direction="column" gap={4}>
       <H2>Security</H2>
@@ -32,48 +69,52 @@ export function Security() {
         <StatCard title="OPA Policies" value={String(opaMiddlewares.length)} subtitle="Policy decision points" />
       </Grid>
 
-      {wafMiddlewares.length > 0 && (
-        <Card css={{ p: '$4' }}>
-          <Flex direction="column" gap={2}>
-            <Text css={{ fontWeight: 600 }}>WAF Middlewares</Text>
-            {wafMiddlewares.map((m: any) => (
-              <Flex key={m.name} justify="between" align="center">
-                <Text>{m.name}</Text>
-                <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
-              </Flex>
-            ))}
+      <Card css={{ p: '$4' }}>
+        <Flex justify="between" align="center" css={{ mb: '$3' }}>
+          <Text css={{ fontWeight: 600 }}>WAF Middlewares</Text>
+          <Button size="small" onClick={handleAddWaf}><FiPlus size={14} /> Add WAF</Button>
+        </Flex>
+        {wafMiddlewares.map((m: any) => (
+          <Flex key={m.name} justify="between" align="center" css={{ py: '$1' }}>
+            <Text>{m.name}</Text>
+            <Flex gap={1}>
+              <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
+              {m.provider === 'file' && <Button size="small" ghost onClick={() => handleDelete(m.name)}><FiTrash2 size={12} /></Button>}
+            </Flex>
           </Flex>
-        </Card>
-      )}
+        ))}
+        {wafMiddlewares.length === 0 && <Text css={{ color: '$textSubtle' }}>No WAF middlewares configured.</Text>}
+      </Card>
 
-      {apiKeyMiddlewares.length > 0 && (
-        <Card css={{ p: '$4' }}>
-          <Flex direction="column" gap={2}>
-            <Text css={{ fontWeight: 600 }}>API Key Middlewares</Text>
-            {apiKeyMiddlewares.map((m: any) => (
-              <Flex key={m.name} justify="between" align="center">
-                <Text>{m.name}</Text>
-                <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
-              </Flex>
-            ))}
+      <Card css={{ p: '$4' }}>
+        <Flex justify="between" align="center" css={{ mb: '$3' }}>
+          <Text css={{ fontWeight: 600 }}>API Key Middlewares</Text>
+          <Button size="small" onClick={handleAddApiKey}><FiPlus size={14} /> Add API Key</Button>
+        </Flex>
+        {apiKeyMiddlewares.map((m: any) => (
+          <Flex key={m.name} justify="between" align="center" css={{ py: '$1' }}>
+            <Text>{m.name}</Text>
+            <Flex gap={1}>
+              <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
+              {m.provider === 'file' && <Button size="small" ghost onClick={() => handleDelete(m.name)}><FiTrash2 size={12} /></Button>}
+            </Flex>
           </Flex>
-        </Card>
-      )}
+        ))}
+        {apiKeyMiddlewares.length === 0 && <Text css={{ color: '$textSubtle' }}>No API Key middlewares configured.</Text>}
+      </Card>
 
       {authMiddlewares.length > 0 && (
         <Card css={{ p: '$4' }}>
-          <Flex direction="column" gap={2}>
-            <Text css={{ fontWeight: 600 }}>Authentication Middlewares</Text>
-            {authMiddlewares.map((m: any) => (
-              <Flex key={m.name} justify="between" align="center">
-                <Text>{m.name}</Text>
-                <Flex gap={1}>
-                  <Badge>{m.type}</Badge>
-                  <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
-                </Flex>
+          <Text css={{ fontWeight: 600, mb: '$2' }}>Authentication Middlewares</Text>
+          {authMiddlewares.map((m: any) => (
+            <Flex key={m.name} justify="between" align="center" css={{ py: '$1' }}>
+              <Text>{m.name}</Text>
+              <Flex gap={1}>
+                <Badge>{m.type}</Badge>
+                <Badge variant={m.status === 'enabled' ? 'green' : 'red'}>{m.status}</Badge>
               </Flex>
-            ))}
-          </Flex>
+            </Flex>
+          ))}
         </Card>
       )}
     </Flex>


### PR DESCRIPTION
Closes #104

- AI Gateway: add/edit/remove LLM providers
- MCP Gateway: add/edit/remove servers and policies
- Security: add WAF rules, API Key middlewares, delete support
- API Management: configure portal settings
- Backend: static config CRUD API (/api/config/static)

All feature pages now have full configuration capabilities.