### PR TITLE
fix: complete acceptance criteria for issues #83, #85, #87

### DIFF
--- a/pkg/apimgmt/events/correlator.go
+++ b/pkg/apimgmt/events/correlator.go
@@ -55,7 +55,7 @@ type Correlator struct {
 	retention time.Duration
 }
 
-// New creates a new event correlator.
+// New creates a new event correlator with automatic retention cleanup.
 func New(config Config) *Correlator {
 	window := config.CorrelationWindow
 	if window <= 0 {
@@ -69,12 +69,21 @@ func New(config Config) *Correlator {
 	if maxEvents <= 0 {
 		maxEvents = 10000
 	}
-	return &Correlator{
+	c := &Correlator{
 		events:    make([]Event, 0, 256),
 		window:    window,
 		maxEvents: maxEvents,
 		retention: retention,
 	}
+	// Auto-cleanup goroutine enforces retention automatically.
+	go func() {
+		ticker := time.NewTicker(retention / 10)
+		defer ticker.Stop()
+		for range ticker.C {
+			c.Cleanup()
+		}
+	}()
+	return c
 }
 
 // Record adds an event.

--- a/pkg/apimgmt/openapi/handler.go
+++ b/pkg/apimgmt/openapi/handler.go
@@ -20,7 +20,6 @@ type Config struct {
 	SpecPath         string `json:"specPath,omitempty" toml:"specPath,omitempty" yaml:"specPath,omitempty"`
 	SpecURL          string `json:"specUrl,omitempty" toml:"specUrl,omitempty" yaml:"specUrl,omitempty"`
 	ValidateRequest  bool   `json:"validateRequest,omitempty" toml:"validateRequest,omitempty" yaml:"validateRequest,omitempty"`
-	ValidateResponse bool   `json:"validateResponse,omitempty" toml:"validateResponse,omitempty" yaml:"validateResponse,omitempty"`
 	ServeSpec        bool   `json:"serveSpec,omitempty" toml:"serveSpec,omitempty" yaml:"serveSpec,omitempty"`
 	SpecEndpoint     string `json:"specEndpoint,omitempty" toml:"specEndpoint,omitempty" yaml:"specEndpoint,omitempty"`
 }

--- a/pkg/apimgmt/portal/handler_test.go
+++ b/pkg/apimgmt/portal/handler_test.go
@@ -1,0 +1,103 @@
+package portal
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthRequired_BlocksUnauthenticatedWrite(t *testing.T) {
+	h := NewHandler(Config{Enabled: true, AuthRequired: true, AuthSecret: "secret123"})
+
+	body := `{"email":"test@example.com","name":"Test"}`
+	req := httptest.NewRequest(http.MethodPost, "/portal/api/developers", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthRequired_AllowsAuthenticatedWrite(t *testing.T) {
+	h := NewHandler(Config{Enabled: true, AuthRequired: true, AuthSecret: "secret123"})
+
+	body := `{"email":"test@example.com","name":"Test"}`
+	req := httptest.NewRequest(http.MethodPost, "/portal/api/developers", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer secret123")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", rr.Code)
+	}
+}
+
+func TestAuthRequired_AllowsUnauthenticatedRead(t *testing.T) {
+	h := NewHandler(Config{Enabled: true, AuthRequired: true, AuthSecret: "secret123"})
+
+	req := httptest.NewRequest(http.MethodGet, "/portal/api/catalog", nil)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestAPIKey_NotReturnedInListing(t *testing.T) {
+	h := NewHandler(Config{Enabled: true, AuthRequired: false})
+
+	// Register developer.
+	body := `{"email":"dev@example.com","name":"Dev"}`
+	req := httptest.NewRequest(http.MethodPost, "/portal/api/developers", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	var dev struct{ ID string }
+	json.NewDecoder(rr.Body).Decode(&dev)
+
+	// Create key.
+	req = httptest.NewRequest(http.MethodPost, "/portal/api/developers/"+dev.ID+"/keys", nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+
+	var keyResp map[string]string
+	json.NewDecoder(rr.Body).Decode(&keyResp)
+	if keyResp["key"] == "" {
+		t.Error("expected key in creation response")
+	}
+
+	// List keys — should NOT contain full key.
+	req = httptest.NewRequest(http.MethodGet, "/portal/api/developers/"+dev.ID+"/keys", nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	body2 := rr.Body.String()
+	if bytes.Contains([]byte(body2), []byte(keyResp["key"])) {
+		t.Error("full key should not appear in listing")
+	}
+}
+
+func TestInvalidEmail_Rejected(t *testing.T) {
+	h := NewHandler(Config{Enabled: true})
+
+	body := `{"email":"notanemail","name":"Test"}`
+	req := httptest.NewRequest(http.MethodPost, "/portal/api/developers", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -669,6 +669,10 @@ type RateLimit struct {
 	// Redis stores the configuration for using Redis as a bucket in the rate-limiting algorithm.
 	// If not specified, Traefik will default to an in-memory bucket for the algorithm.
 	Redis *Redis `json:"redis,omitempty" toml:"redis,omitempty" yaml:"redis,omitempty" export:"true"`
+
+	// FailOpen allows requests through when the limiter backend (Redis) is unavailable.
+	// Default is false (fail-closed: return 500 on error).
+	FailOpen bool `json:"failOpen,omitempty" toml:"failOpen,omitempty" yaml:"failOpen,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values on a RateLimit.

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -37,6 +37,7 @@ type rateLimiter struct {
 	sourceMatcher utils.SourceExtractor
 	next          http.Handler
 	logger        *zerolog.Logger
+	failOpen      bool
 
 	limiter limiter
 }
@@ -120,6 +121,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		next:          next,
 		sourceMatcher: sourceMatcher,
 		limiter:       limiter,
+		failOpen:      config.FailOpen,
 	}, nil
 }
 
@@ -150,6 +152,11 @@ func (rl *rateLimiter) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	delay, err := rl.limiter.Allow(ctx, rlSource)
 	if err != nil {
 		rl.logger.Error().Err(err).Msg("Could not insert/update bucket")
+		if rl.failOpen {
+			rl.logger.Warn().Msg("Fail-open: allowing request despite limiter error")
+			rl.next.ServeHTTP(rw, req)
+			return
+		}
 		observability.SetStatusErrorf(ctx, "Could not insert/update bucket")
 		http.Error(rw, "Could not insert/update bucket", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Ref #83, Ref #85, Ref #87

**#87:**
- Remove ValidateResponse from OpenAPI config (unused contract)
- Correlator auto-cleanup goroutine (retention enforced)

**#85:**
- Add FailOpen config to RateLimit (configurable failure mode)
- Default fail-closed, opt-in fail-open with warning log

**#83:**
- Security test suite: 5 tests covering auth enforcement, key secrecy, input validation
- All tests pass