### PR TITLE
feat: add Grafana dashboard page and encrypted cluster mTLS

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -140,6 +140,7 @@ func (h *Handler) createRouter() *mux.Router {
 	apiRouter.Methods(http.MethodGet).Path("/api/mcp/policies").HandlerFunc(h.getMCPPolicies)
 	apiRouter.Methods(http.MethodGet).Path("/api/apimgmt/status").HandlerFunc(h.getAPIMgmtStatus)
 	apiRouter.Methods(http.MethodGet).Path("/api/apimgmt/portal").HandlerFunc(h.getAPIMgmtPortal)
+	apiRouter.Methods(http.MethodGet).Path("/api/grafana/dashboards").HandlerFunc(h.getGrafanaDashboards)
 
 	// CRUD: Dynamic configuration management.
 	if h.staticConfig.Providers != nil && h.staticConfig.Providers.File != nil && h.staticConfig.Providers.File.Filename != "" {

--- a/pkg/api/handler_grafana.go
+++ b/pkg/api/handler_grafana.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/traefik/traefik/v3/pkg/apimgmt/grafana"
+)
+
+func (h *Handler) getGrafanaDashboards(rw http.ResponseWriter, _ *http.Request) {
+	dashboards := grafana.BuiltinDashboards()
+	rw.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(rw).Encode(dashboards)
+}

--- a/pkg/cluster/mtls.go
+++ b/pkg/cluster/mtls.go
@@ -1,0 +1,189 @@
+package cluster
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// MTLSConfig holds the mTLS cluster communication configuration.
+type MTLSConfig struct {
+	Enabled  bool   `json:"enabled" toml:"enabled" yaml:"enabled"`
+	CertDir  string `json:"certDir,omitempty" toml:"certDir,omitempty" yaml:"certDir,omitempty"`
+	CAFile   string `json:"caFile,omitempty" toml:"caFile,omitempty" yaml:"caFile,omitempty"`
+	CertFile string `json:"certFile,omitempty" toml:"certFile,omitempty" yaml:"certFile,omitempty"`
+	KeyFile  string `json:"keyFile,omitempty" toml:"keyFile,omitempty" yaml:"keyFile,omitempty"`
+}
+
+// InternalCA manages an auto-generated internal CA for cluster mTLS.
+type InternalCA struct {
+	caCert    *x509.Certificate
+	caKey     *ecdsa.PrivateKey
+	caPEM     []byte
+	certDir   string
+}
+
+// NewInternalCA creates or loads an internal CA for cluster communication.
+func NewInternalCA(config MTLSConfig) (*InternalCA, error) {
+	certDir := config.CertDir
+	if certDir == "" {
+		certDir = "/etc/traefik/cluster-certs"
+	}
+
+	if err := os.MkdirAll(certDir, 0700); err != nil {
+		return nil, fmt.Errorf("creating cert dir: %w", err)
+	}
+
+	caPath := filepath.Join(certDir, "ca.pem")
+	keyPath := filepath.Join(certDir, "ca-key.pem")
+
+	// Try to load existing CA.
+	if _, err := os.Stat(caPath); err == nil {
+		return loadCA(caPath, keyPath, certDir)
+	}
+
+	// Generate new CA.
+	return generateCA(caPath, keyPath, certDir)
+}
+
+func generateCA(caPath, keyPath, certDir string) (*InternalCA, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating CA key: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"traefik-api-srv"},
+			CommonName:   "traefik-api-srv Internal CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("creating CA cert: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CA cert: %w", err)
+	}
+
+	// Write CA cert.
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err := os.WriteFile(caPath, caPEM, 0644); err != nil {
+		return nil, fmt.Errorf("writing CA cert: %w", err)
+	}
+
+	// Write CA key.
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return nil, fmt.Errorf("writing CA key: %w", err)
+	}
+
+	log.Info().Str("path", caPath).Msg("Generated internal CA for cluster mTLS")
+
+	return &InternalCA{caCert: cert, caKey: key, caPEM: caPEM, certDir: certDir}, nil
+}
+
+func loadCA(caPath, keyPath, certDir string) (*InternalCA, error) {
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(caPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	key, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info().Str("path", caPath).Msg("Loaded internal CA for cluster mTLS")
+	return &InternalCA{caCert: cert, caKey: key, caPEM: caPEM, certDir: certDir}, nil
+}
+
+// IssueCert issues a node certificate signed by the internal CA.
+func (ca *InternalCA) IssueCert(nodeID string, ips []net.IP) (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generating node key: %w", err)
+	}
+
+	serial, _ := rand.Int(rand.Reader, big.NewInt(1<<62))
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			Organization: []string{"traefik-api-srv"},
+			CommonName:   nodeID,
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IPAddresses: ips,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca.caCert, &key.PublicKey, ca.caKey)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("signing node cert: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	log.Info().Str("node", nodeID).Msg("Issued node certificate")
+	return tlsCert, nil
+}
+
+// TLSConfig returns a tls.Config for mTLS communication between nodes.
+func (ca *InternalCA) TLSConfig(nodeCert tls.Certificate) *tls.Config {
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca.caPEM)
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{nodeCert},
+		ClientCAs:    pool,
+		RootCAs:      pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+}
+
+// CAPem returns the CA certificate in PEM format.
+func (ca *InternalCA) CAPem() []byte {
+	return ca.caPEM
+}

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -10,7 +10,7 @@ import fetch from './libs/fetch'
 import { VersionProvider } from 'contexts/version'
 import { useIsDarkMode } from 'hooks/use-theme'
 import ErrorSuspenseWrapper from 'layout/ErrorSuspenseWrapper'
-import { Dashboard, HTTPPages, NotFound, TCPPages, UDPPages, CertificatesPages, AIGateway, Security, MCPGateway, APIManagement, ConfigManager, Distributed, Clusters } from 'pages'
+import { Dashboard, HTTPPages, NotFound, TCPPages, UDPPages, CertificatesPages, AIGateway, Security, MCPGateway, APIManagement, ConfigManager, Distributed, Clusters, GrafanaDashboards } from 'pages'
 import { DashboardSkeleton } from 'pages/dashboard/Dashboard'
 
 export const LIGHT_THEME = lightTheme('blue')
@@ -78,6 +78,7 @@ export const Routes = () => {
           <Route path="/config" element={<ConfigManager />} />
           <Route path="/distributed" element={<Distributed />} />
           <Route path="/clusters" element={<Clusters />} />
+          <Route path="/grafana" element={<GrafanaDashboards />} />
 
           <Route path="*" element={<NotFound />} />
         </RouterRoutes>

--- a/webui/src/pages/grafana/GrafanaDashboards.tsx
+++ b/webui/src/pages/grafana/GrafanaDashboards.tsx
@@ -1,0 +1,67 @@
+import { Button, Card, Flex, H2, Text, Badge } from '@traefik-labs/faency'
+import { useState } from 'react'
+import { FiClipboard, FiCheck } from 'react-icons/fi'
+import useSWR from 'swr'
+
+const API_BASE = (window as any).APIUrl || '/api'
+
+async function fetchDashboards() {
+  const res = await fetch(`${API_BASE}/grafana/dashboards`)
+  if (!res.ok) return []
+  return res.json()
+}
+
+export function GrafanaDashboards() {
+  const { data: dashboards } = useSWR('grafana-dashboards', fetchDashboards)
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const handleCopy = (dashboard: any) => {
+    const json = JSON.stringify(dashboard, null, 2)
+    navigator.clipboard.writeText(json)
+    setCopied(dashboard.uid)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  return (
+    <Flex direction="column" gap={4}>
+      <H2>Grafana Dashboards</H2>
+      <Text css={{ color: '$textSubtle' }}>Pre-built Grafana dashboard definitions. Copy JSON and import into Grafana.</Text>
+
+      {Array.isArray(dashboards) && dashboards.map((d: any) => (
+        <Card key={d.uid} css={{ p: '$4' }}>
+          <Flex justify="between" align="center">
+            <Flex direction="column" gap={1}>
+              <Text css={{ fontWeight: 600, fontSize: '$4' }}>{d.title}</Text>
+              <Text css={{ color: '$textSubtle', fontSize: '$2' }}>{d.description}</Text>
+              <Flex gap={1} css={{ mt: '$1' }}>
+                <Badge>{d.panels?.length || 0} panels</Badge>
+                <Badge variant="blue">{d.uid}</Badge>
+              </Flex>
+            </Flex>
+            <Button
+              size="small"
+              variant={copied === d.uid ? 'green' : 'secondary'}
+              onClick={() => handleCopy(d)}
+            >
+              {copied === d.uid ? <><FiCheck size={14} /> Copied!</> : <><FiClipboard size={14} /> Copy JSON</>}
+            </Button>
+          </Flex>
+
+          {d.panels && (
+            <Flex gap={1} wrap="wrap" css={{ mt: '$3' }}>
+              {d.panels.map((p: any, i: number) => (
+                <Badge key={i} variant="gray" css={{ fontSize: '$1' }}>{p.title} ({p.type})</Badge>
+              ))}
+            </Flex>
+          )}
+        </Card>
+      ))}
+
+      {(!dashboards || dashboards.length === 0) && (
+        <Card css={{ p: '$4' }}>
+          <Text css={{ color: '$textSubtle' }}>No dashboards available.</Text>
+        </Card>
+      )}
+    </Flex>
+  )
+}

--- a/webui/src/pages/grafana/index.ts
+++ b/webui/src/pages/grafana/index.ts
@@ -1,0 +1,1 @@
+export { GrafanaDashboards } from './GrafanaDashboards'

--- a/webui/src/pages/index.ts
+++ b/webui/src/pages/index.ts
@@ -12,4 +12,5 @@ export { APIManagement } from './apimgmt'
 export { ConfigManager } from './config'
 export { Distributed } from './distributed'
 export { Clusters } from './clusters'
+export { GrafanaDashboards } from './grafana'
 export { HTTPPages, TCPPages, UDPPages, CertificatesPages }

--- a/webui/src/routes.tsx
+++ b/webui/src/routes.tsx
@@ -6,7 +6,7 @@ import {
   LiaHomeSolid,
   LiaCertificateSolid,
 } from 'react-icons/lia'
-import { MdOutlineSecurity, MdOutlineSmartToy, MdOutlineHub, MdOutlineApi, MdOutlineSettings } from 'react-icons/md'
+import { MdOutlineSecurity, MdOutlineSmartToy, MdOutlineHub, MdOutlineApi, MdOutlineSettings, MdOutlineDashboard } from 'react-icons/md'
 
 export type Route = {
   path: string
@@ -184,6 +184,17 @@ export const ROUTES: RouteSections[] = [
         path: '/clusters',
         label: 'Multi-Cluster',
         icon: <MdOutlineApi color="currentColor" size={20} />,
+      },
+    ],
+  },
+  {
+    section: 'grafana',
+    sectionLabel: 'Observability',
+    items: [
+      {
+        path: '/grafana',
+        label: 'Grafana Dashboards',
+        icon: <MdOutlineDashboard color="currentColor" size={20} />,
       },
     ],
   },


### PR DESCRIPTION
Closes #74, Closes #110

- Grafana page: list dashboards, copy JSON to clipboard
- Cluster mTLS: internal CA, node cert issuance, TLS 1.3 mutual auth