### PR TITLE
feat(core): add dashboard auth and platform status overview

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -66,7 +66,13 @@ type Handler struct {
 // NewBuilder returns a http.Handler builder based on runtime.Configuration.
 func NewBuilder(staticConfig static.Configuration, tlsManager *tls.Manager) func(*runtime.Configuration) http.Handler {
 	return func(configuration *runtime.Configuration) http.Handler {
-		return New(staticConfig, configuration).WithTLSManager(tlsManager).createRouter()
+		h := New(staticConfig, configuration).WithTLSManager(tlsManager)
+		router := h.createRouter()
+		// Wrap with basic auth if configured.
+		if staticConfig.API != nil && staticConfig.API.AuthUser != "" && staticConfig.API.AuthPassword != "" {
+			return h.basicAuthMiddleware(router)
+		}
+		return router
 	}
 }
 

--- a/pkg/api/handler_auth.go
+++ b/pkg/api/handler_auth.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// basicAuthMiddleware protects the dashboard and API with basic authentication.
+func (h *Handler) basicAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		user, pass, ok := req.BasicAuth()
+		if !ok ||
+			subtle.ConstantTimeCompare([]byte(user), []byte(h.staticConfig.API.AuthUser)) != 1 ||
+			subtle.ConstantTimeCompare([]byte(pass), []byte(h.staticConfig.API.AuthPassword)) != 1 {
+			rw.Header().Set("WWW-Authenticate", `Basic realm="traefik-api-srv"`)
+			http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(rw, req)
+	})
+}

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -190,6 +190,8 @@ type API struct {
 	Debug              bool   `description:"Enable additional endpoints for debugging and profiling." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
 	DisableDashboardAd bool   `description:"Disable ad in the dashboard." json:"disableDashboardAd,omitempty" toml:"disableDashboardAd,omitempty" yaml:"disableDashboardAd,omitempty" export:"true"`
 	DashboardName      string `description:"Custom name for the dashboard." json:"dashboardName,omitempty" toml:"dashboardName,omitempty" yaml:"dashboardName,omitempty" export:"true"`
+	AuthUser           string `description:"Basic auth username for dashboard/API." json:"authUser,omitempty" toml:"authUser,omitempty" yaml:"authUser,omitempty"`
+	AuthPassword       string `description:"Basic auth password for dashboard/API." json:"authPassword,omitempty" toml:"authPassword,omitempty" yaml:"authPassword,omitempty" loggable:"false"`
 	// TODO: Re-enable statistics
 	// Statistics      *types.Statistics `description:"Enable more detailed statistics." json:"statistics,omitempty" toml:"statistics,omitempty" yaml:"statistics,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 }

--- a/webui/src/pages/dashboard/Dashboard.tsx
+++ b/webui/src/pages/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { Card, CSS, Flex, Grid, H2, Text } from '@traefik-labs/faency'
+import { Badge, Card, CSS, Flex, Grid, H2, Text } from '@traefik-labs/faency'
 import { ReactNode, useMemo } from 'react'
 import useSWR from 'swr'
 
@@ -8,6 +8,66 @@ import ResourceCard from 'components/resources/ResourceCard'
 import TraefikResourceStatsCard, { StatsCardSkeleton } from 'components/resources/TraefikResourceStatsCard'
 import PageTitle from 'layout/PageTitle'
 import { capitalizeFirstLetter } from 'utils/string'
+
+
+const API_BASE = (window as any).APIUrl || '/api'
+
+const PlatformStatusCard = ({ title, status, detail, href }: { title: string; status: string; detail: string; href: string }) => (
+  <a href={`#${href}`} style={{ textDecoration: 'none' }}>
+    <Card css={{ p: '$3', cursor: 'pointer', '&:hover': { borderColor: '$blue7' } }}>
+      <Flex direction="column" gap={1}>
+        <Flex justify="between" align="center">
+          <Text css={{ fontWeight: 600, fontSize: '$3' }}>{title}</Text>
+          <Badge variant={status === 'active' ? 'green' : status === 'available' ? 'blue' : 'gray'} css={{ fontSize: '$1' }}>
+            {status}
+          </Badge>
+        </Flex>
+        <Text css={{ fontSize: '$2', color: '$textSubtle' }}>{detail}</Text>
+      </Flex>
+    </Card>
+  </a>
+)
+
+const PlatformStatus = () => {
+  const { data: aiStatus } = useSWR('ai-status', () => fetch(`${API_BASE}/ai/status`).then(r => r.json()).catch(() => null))
+  const { data: mcpStatus } = useSWR('mcp-status', () => fetch(`${API_BASE}/mcp/status`).then(r => r.json()).catch(() => null))
+  const { data: middlewares } = useSWR('/http/middlewares')
+
+  const securityCount = Array.isArray(middlewares)
+    ? middlewares.filter((m: any) => ['waf', 'apikey', 'jwt', 'oidc', 'hmac', 'ldap', 'opa'].includes(m.type)).length
+    : 0
+  const cacheCount = Array.isArray(middlewares) ? middlewares.filter((m: any) => m.type === 'httpcache').length : 0
+  const rateLimitCount = Array.isArray(middlewares) ? middlewares.filter((m: any) => m.type === 'ratelimit').length : 0
+
+  return (
+    <Grid columns={{ '@initial': 2, '@md': 4 }} gap={3}>
+      <PlatformStatusCard
+        title="🤖 AI Gateway"
+        status={aiStatus?.enabled ? 'active' : 'available'}
+        detail={aiStatus?.enabled ? `${aiStatus.components} providers` : 'Not configured'}
+        href="/ai"
+      />
+      <PlatformStatusCard
+        title="🔧 MCP Gateway"
+        status={mcpStatus?.enabled ? 'active' : 'available'}
+        detail={mcpStatus?.enabled ? `${mcpStatus.components} servers` : 'Not configured'}
+        href="/mcp"
+      />
+      <PlatformStatusCard
+        title="🛡️ Security"
+        status={securityCount > 0 ? 'active' : 'available'}
+        detail={securityCount > 0 ? `${securityCount} active middlewares` : 'No security middlewares'}
+        href="/security"
+      />
+      <PlatformStatusCard
+        title="⚡ Distributed"
+        status={rateLimitCount + cacheCount > 0 ? 'active' : 'available'}
+        detail={`${rateLimitCount} rate limits, ${cacheCount} caches`}
+        href="/distributed"
+      />
+    </Grid>
+  )
+}
 
 const RESOURCES = ['routers', 'services', 'middlewares']
 
@@ -78,6 +138,10 @@ export const Dashboard = () => {
   return (
     <Flex direction="column" gap={6}>
       <PageTitle title="Dashboard" />
+
+      {/* Platform Status */}
+      <PlatformStatus />
+
       <SectionContainer title="Entrypoints" css={{ mt: 0 }}>
         {entrypoints?.map((i, idx) => (
           <ResourceCard


### PR DESCRIPTION
- BasicAuth for dashboard/API (authUser + authPassword in static config)
- Platform Status cards on main dashboard (AI, MCP, Security, Distributed)
- Cards show active/available state and link to feature pages
- Constant-time password comparison