### PR TITLE
fix(api): protect write operations with BasicAuth

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -66,13 +66,7 @@ type Handler struct {
 // NewBuilder returns a http.Handler builder based on runtime.Configuration.
 func NewBuilder(staticConfig static.Configuration, tlsManager *tls.Manager) func(*runtime.Configuration) http.Handler {
 	return func(configuration *runtime.Configuration) http.Handler {
-		h := New(staticConfig, configuration).WithTLSManager(tlsManager)
-		router := h.createRouter()
-		// Wrap with basic auth if configured.
-		if staticConfig.API != nil && staticConfig.API.AuthUser != "" && staticConfig.API.AuthPassword != "" {
-			return h.basicAuthMiddleware(router)
-		}
-		return router
+		return New(staticConfig, configuration).WithTLSManager(tlsManager).createRouter()
 	}
 }
 
@@ -151,7 +145,7 @@ func (h *Handler) createRouter() *mux.Router {
 	// CRUD: Dynamic configuration management.
 	if h.staticConfig.Providers != nil && h.staticConfig.Providers.File != nil && h.staticConfig.Providers.File.Filename != "" {
 		dcm := newDynamicConfigManager(h.staticConfig.Providers.File.Filename)
-		dcm.RegisterCRUDRoutes(apiRouter)
+		dcm.RegisterCRUDRoutes(apiRouter, h.authWrap)
 	}
 
 	// Static configuration management (for AI/MCP/APIMgmt settings).
@@ -159,12 +153,12 @@ func (h *Handler) createRouter() *mux.Router {
 	if staticPath != "" {
 		scm := newStaticConfigManager(staticPath)
 		apiRouter.Methods(http.MethodGet).Path("/api/config/static").HandlerFunc(scm.getStaticSection)
-		apiRouter.Methods(http.MethodPut).Path("/api/config/static").HandlerFunc(scm.putStaticSection)
-		apiRouter.Methods(http.MethodDelete).Path("/api/config/static").HandlerFunc(scm.deleteStaticSection)
+		apiRouter.Methods(http.MethodPut).Path("/api/config/static").HandlerFunc(h.authWrap(scm.putStaticSection))
+		apiRouter.Methods(http.MethodDelete).Path("/api/config/static").HandlerFunc(h.authWrap(scm.deleteStaticSection))
 
 		// Static config auto-reload.
 		sr := newStaticReloader(staticPath, true)
-		apiRouter.Methods(http.MethodPost).Path("/api/reload").HandlerFunc(sr.handleReload)
+		apiRouter.Methods(http.MethodPost).Path("/api/reload").HandlerFunc(h.authWrap(sr.handleReload))
 		apiRouter.Methods(http.MethodGet).Path("/api/reload").HandlerFunc(sr.handleReloadStatus)
 
 		// Backup and restore.
@@ -173,8 +167,8 @@ func (h *Handler) createRouter() *mux.Router {
 			dynamicPath = h.staticConfig.Providers.File.Filename
 		}
 		bh := newBackupHandler(staticPath, dynamicPath)
-		apiRouter.Methods(http.MethodGet).Path("/api/config/backup").HandlerFunc(bh.handleBackup)
-		apiRouter.Methods(http.MethodPost).Path("/api/config/restore").HandlerFunc(bh.handleRestore)
+		apiRouter.Methods(http.MethodGet).Path("/api/config/backup").HandlerFunc(h.authWrap(bh.handleBackup))
+		apiRouter.Methods(http.MethodPost).Path("/api/config/restore").HandlerFunc(h.authWrap(bh.handleRestore))
 	}
 
 	version.Handler{}.Append(apiRouter)

--- a/pkg/api/handler_auth.go
+++ b/pkg/api/handler_auth.go
@@ -5,17 +5,28 @@ import (
 	"net/http"
 )
 
-// basicAuthMiddleware protects the dashboard and API with basic authentication.
-func (h *Handler) basicAuthMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		user, pass, ok := req.BasicAuth()
-		if !ok ||
-			subtle.ConstantTimeCompare([]byte(user), []byte(h.staticConfig.API.AuthUser)) != 1 ||
-			subtle.ConstantTimeCompare([]byte(pass), []byte(h.staticConfig.API.AuthPassword)) != 1 {
-			rw.Header().Set("WWW-Authenticate", `Basic realm="traefik-api-srv"`)
-			http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+// requireAuth checks basic auth for write operations. Returns true if authorized.
+func (h *Handler) requireAuth(rw http.ResponseWriter, req *http.Request) bool {
+	if h.staticConfig.API == nil || h.staticConfig.API.AuthUser == "" {
+		return true
+	}
+	user, pass, ok := req.BasicAuth()
+	if !ok ||
+		subtle.ConstantTimeCompare([]byte(user), []byte(h.staticConfig.API.AuthUser)) != 1 ||
+		subtle.ConstantTimeCompare([]byte(pass), []byte(h.staticConfig.API.AuthPassword)) != 1 {
+		rw.Header().Set("WWW-Authenticate", `Basic realm="traefik-api-srv"`)
+		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	return true
+}
+
+// authWrap wraps a handler with auth check.
+func (h *Handler) authWrap(next http.HandlerFunc) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		if !h.requireAuth(rw, req) {
 			return
 		}
-		next.ServeHTTP(rw, req)
-	})
+		next(rw, req)
+	}
 }

--- a/pkg/api/handler_crud.go
+++ b/pkg/api/handler_crud.go
@@ -73,17 +73,17 @@ func (m *DynamicConfigManager) save(cfg *dynamicConfig) error {
 }
 
 // RegisterCRUDRoutes registers CRUD endpoints on the given router.
-func (m *DynamicConfigManager) RegisterCRUDRoutes(router *mux.Router) {
+func (m *DynamicConfigManager) RegisterCRUDRoutes(router *mux.Router, authWrap func(http.HandlerFunc) http.HandlerFunc) {
 	router.Methods(http.MethodGet).Path("/api/config/dynamic").HandlerFunc(m.getDynamic)
 
-	router.Methods(http.MethodPut).Path("/api/config/http/routers/{name}").HandlerFunc(m.putRouter)
-	router.Methods(http.MethodDelete).Path("/api/config/http/routers/{name}").HandlerFunc(m.deleteRouter)
+	router.Methods(http.MethodPut).Path("/api/config/http/routers/{name}").HandlerFunc(authWrap(m.putRouter))
+	router.Methods(http.MethodDelete).Path("/api/config/http/routers/{name}").HandlerFunc(authWrap(m.deleteRouter))
 
-	router.Methods(http.MethodPut).Path("/api/config/http/services/{name}").HandlerFunc(m.putService)
-	router.Methods(http.MethodDelete).Path("/api/config/http/services/{name}").HandlerFunc(m.deleteService)
+	router.Methods(http.MethodPut).Path("/api/config/http/services/{name}").HandlerFunc(authWrap(m.putService))
+	router.Methods(http.MethodDelete).Path("/api/config/http/services/{name}").HandlerFunc(authWrap(m.deleteService))
 
-	router.Methods(http.MethodPut).Path("/api/config/http/middlewares/{name}").HandlerFunc(m.putMiddleware)
-	router.Methods(http.MethodDelete).Path("/api/config/http/middlewares/{name}").HandlerFunc(m.deleteMiddleware)
+	router.Methods(http.MethodPut).Path("/api/config/http/middlewares/{name}").HandlerFunc(authWrap(m.putMiddleware))
+	router.Methods(http.MethodDelete).Path("/api/config/http/middlewares/{name}").HandlerFunc(authWrap(m.deleteMiddleware))
 }
 
 func (m *DynamicConfigManager) getDynamic(rw http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
- authWrap on PUT/DELETE/POST endpoints
- GET remains open for dashboard
- Backward compatible (no auth = open)